### PR TITLE
[Fix] Exit status code correctly send to snitch + too many requests exception handling

### DIFF
--- a/src/main/java/com/agorapulse/micronaut/snitch/DefaultSnitchService.java
+++ b/src/main/java/com/agorapulse/micronaut/snitch/DefaultSnitchService.java
@@ -20,8 +20,8 @@ public class DefaultSnitchService implements SnitchService {
     private final SnitchClient client;
     private final SnitchJobConfiguration configuration;
 
-    private long lastSuccessfulCallTime = 0;
-    private long lastTooManyRequestsCallTime = 0;
+    private long lastSuccessfulCallTime;
+    private long lastTooManyRequestsCallTime;
 
     public DefaultSnitchService(SnitchClient client, SnitchJobConfiguration configuration) {
         this.client = client;


### PR DESCRIPTION
Snitch is expecting exit status code in the `s` query string paramerter: `0` for success, and `1` or more for errors.

We are currently sending `1` for success.

I've also added too many requests exception handling so that we do not retry too hard on snitch if we get this exception.
We theoretically can't call snitch more than once per minute otherwise, we get this exception (which might occur if we do have several Lambda functions running in //)