### PR TITLE
[branch ch52131] Log warning when snitches id is not set

### DIFF
--- a/libs/micronaut-snitch/src/main/java/com/agorapulse/micronaut/snitch/DefaultSnitchFactory.java
+++ b/libs/micronaut-snitch/src/main/java/com/agorapulse/micronaut/snitch/DefaultSnitchFactory.java
@@ -21,7 +21,6 @@ import io.micronaut.context.annotation.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nullable;
 import javax.inject.Named;
 import javax.inject.Singleton;
 

--- a/libs/micronaut-snitch/src/main/java/com/agorapulse/micronaut/snitch/DefaultSnitchFactory.java
+++ b/libs/micronaut-snitch/src/main/java/com/agorapulse/micronaut/snitch/DefaultSnitchFactory.java
@@ -18,7 +18,10 @@
 package com.agorapulse.micronaut.snitch;
 
 import io.micronaut.context.annotation.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
@@ -27,6 +30,8 @@ import javax.inject.Singleton;
  */
 @Factory
 public class DefaultSnitchFactory {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultSnitchFactory.class);
 
     @EachBean(SnitchJobConfiguration.class)
     @Requires(property = "snitches.jobs")
@@ -49,7 +54,11 @@ public class DefaultSnitchFactory {
     @Singleton
     @Named("default")
     @Requires(missingProperty = "snitches.id")
-    public SnitchService noopSnitchService() {
+    public SnitchService noopSnitchService(@Value("${snitches.disabled:false}") boolean snitchesDisabled) {
+        if (!snitchesDisabled) {
+            LOGGER.warn("Micronaut Snitch is not configured! Please set snitches.id configuration property or set snitches.disabled to true to ignore this warning.");
+        }
+
         return NoopSnitchService.INSTANCE;
     }
 


### PR DESCRIPTION
This change will add warning logging If the snitch is not configured properly. For the application and functions using Sentry this will be logged as a new event so we need to disable the it with `SNITCHES_DISABLED` environment variable where the snitches are not required (beta).