### PR TITLE
Upgrade micronaut-snitch to Micronaut 5.x

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,7 +1,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
-# Copyright 2020-2021 Agorapulse.
+# Copyright 2020-2026 Agorapulse.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -23,17 +23,11 @@ jobs:
   check:
     name: Check
     runs-on: ubuntu-latest
-    env:
-      COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
-
     steps:
-      - uses: actions/checkout@v3
-      - name: Setup Java 17
-        uses: actions/setup-java@v3
-        with:
-          distribution: corretto
-          java-version: 17
-      - name: Check
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: check coveralls
+    - uses: actions/checkout@v4
+    - uses: actions/setup-java@v4
+      with:
+        distribution: zulu
+        java-version: 25
+    - uses: gradle/actions/setup-gradle@v5
+    - run: ./gradlew check

--- a/.github/workflows/license_updater.yml
+++ b/.github/workflows/license_updater.yml
@@ -8,16 +8,14 @@ jobs:
     name: Formats the license headers for a new year
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - name: Setup Java 17
-        uses: actions/setup-java@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
         with:
-          distribution: corretto
-          java-version: 17
+          distribution: zulu
+          java-version: 25
+      - uses: gradle/actions/setup-gradle@v5
       - name: License Format
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: licenseFormat
+        run: ./gradlew licenseFormat
       - name: Create Pull Request
         id: cpr
         uses: peter-evans/create-pull-request@v3

--- a/.github/workflows/publish_documentation.yml
+++ b/.github/workflows/publish_documentation.yml
@@ -6,23 +6,28 @@ jobs:
   publish:
     name: Publish Documentation
     runs-on: ubuntu-latest
-    env:
-      GRADLE_OPTS: "-Xmx6g -Xms4g"
     steps:
-      - uses: actions/checkout@v2
-      - name: Setup Java 17
-        uses: actions/setup-java@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
         with:
-          distribution: corretto
-          java-version: 17
-          cache: gradle
+          distribution: zulu
+          java-version: 25
       - name: Get Latest Release
         id: latest_version
         uses: abatilo/release-info-action@v1.3.0
         with:
           owner: agorapulse
           repo: micronaut-snitch
+      - uses: gradle/actions/setup-gradle@v5
+      - name: Configure git identity for gitPublishCommit
+        run: |
+          git config --global user.name 'Agorapulse Bot'
+          git config --global user.email 'oss@agorapulse.com'
       - name: Publish GitHub Pages
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: gitPublishPush -Pversion=${{ steps.latest_version.outputs.latest_tag }} -Prelease=true -Dorg.ajoberstar.grgit.auth.username=${{ secrets.AGORAPULSE_BOT_PERSONAL_TOKEN }}
+        env:
+          GIT_PUBLISH_USERNAME: agorapulse-bot
+          GIT_PUBLISH_PASSWORD: ${{ secrets.AGORAPULSE_BOT_PERSONAL_TOKEN }}
+        run: |
+          ./gradlew :guide:gitPublishPush \
+            -Pversion=${{ steps.latest_version.outputs.latest_tag }} \
+            -Prelease=true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,15 +7,12 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    env:
-      GRADLE_OPTS: "-Xmx6g -Xms4g"
     steps:
-      - uses: actions/checkout@v2
-      - name: Setup Java 17
-        uses: actions/setup-java@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
         with:
-          distribution: corretto
-          java-version: 17
+          distribution: zulu
+          java-version: 25
       - name: Semantic Version
         id: version
         uses: ncipollo/semantic-version-action@v1
@@ -25,17 +22,27 @@ jobs:
         with:
           fileName: 'secret.pgp'
           encodedString: ${{ secrets.SIGNING_SECRET_KEY_BASE64 }}
+      - uses: gradle/actions/setup-gradle@v5
+      - name: Configure git identity for gitPublishCommit
+        run: |
+          git config --global user.name 'Agorapulse Bot'
+          git config --global user.email 'oss@agorapulse.com'
       - name: Release
-        uses: gradle/gradle-build-action@v2
         env:
-          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
-          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
           SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
           SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
           SIGNING_SECRET_KEY_PATH: ${{ steps.write_file.outputs.filePath }}
-        with:
-          arguments: gitPublishPush publishToSonatype closeAndReleaseSonatypeStagingRepository -Pversion=${{ steps.version.outputs.tag }} -Dorg.ajoberstar.grgit.auth.username=${{ secrets.AGORAPULSE_BOT_PERSONAL_TOKEN }}
+          GIT_PUBLISH_USERNAME: agorapulse-bot
+          GIT_PUBLISH_PASSWORD: ${{ secrets.AGORAPULSE_BOT_PERSONAL_TOKEN }}
+        run: |
+          ./gradlew :guide:gitPublishPush publishAndReleaseToMavenCentral \
+            -Pversion=${{ steps.version.outputs.tag }} \
+            -PmavenCentralUsername=${{ secrets.MAVEN_CENTRAL_USERNAME }} \
+            -PmavenCentralPassword=${{ secrets.MAVEN_CENTRAL_PASSWORD }} \
+            -Prelease=true \
+            --stacktrace
   ping:
+    if: ${{ !github.event.release.prerelease }}
     name: Notify Upstream Repositories
     runs-on: ubuntu-latest
     needs: [ release ]
@@ -45,7 +52,7 @@ jobs:
           - agorapulse/agorapulse-bom
           - agorapulse/agorapulse-oss
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Semantic Version
         id: version
         uses: ncipollo/semantic-version-action@v1
@@ -55,4 +62,4 @@ jobs:
           token: ${{ secrets.AGORAPULSE_BOT_PERSONAL_TOKEN }}
           repository: ${{ matrix.repository }}
           event-type: ap-new-version-released-event
-          client-payload: '{ "group": "com.agorapulse", "module": "micronaut-snitch", "micronautCompatibility": [4], "version": "${{ steps.version.outputs.tag }}", "property" : "micronaut.snitch.version", "github" : ${{ toJson(github) }} }'
+          client-payload: '{ "group": "com.agorapulse", "module": "micronaut-snitch", "micronautCompatibility": [5], "version": "${{ steps.version.outputs.tag }}", "property" : "micronaut.snitch.version", "github" : ${{ toJson(github) }} }'

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2023 Agorapulse.
+ * Copyright 2020-2026 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,183 +16,67 @@
  * limitations under the License.
  */
 plugins {
-    id 'org.kordamp.gradle.groovy-project'
-    id 'org.kordamp.gradle.checkstyle'
-    id 'org.kordamp.gradle.codenarc'
-    id 'org.kordamp.gradle.coveralls'
-    id 'io.github.gradle-nexus.publish-plugin'
+    id 'lifecycle-base'
 }
 
-if (!project.hasProperty('ossrhUsername'))      ext.ossrhUsername       = System.getenv('SONATYPE_USERNAME') ?: '**UNDEFINED**'
-if (!project.hasProperty('ossrhPassword'))      ext.ossrhPassword       = System.getenv('SONATYPE_PASSWORD') ?: '**UNDEFINED**'
-if (!project.hasProperty('signingKeyId'))       ext.signingKeyId        = System.getenv('SIGNING_KEY_ID') ?: '**UNDEFINED**'
-if (!project.hasProperty('signingPassword'))    ext.signingPassword     = System.getenv('SIGNING_PASSWORD') ?: '**UNDEFINED**'
-if (!project.hasProperty('signingSecretKey'))   ext.signingSecretKey    = System.getenv('SIGNING_SECRET_KEY_PATH') ? rootProject.file(System.getenv('SIGNING_SECRET_KEY_PATH')).text : '**UNDEFINED**'
-
-config {
-    release = (rootProject.findProperty('release') ?: false).toBoolean()
-
-    info {
-        name        = 'Micronaut Snitch'
-        vendor      = 'Agorapulse'
-        description = 'Micronaut Snitch'
-
-        links {
-            website      = "https://github.com/" + slug
-            issueTracker = "https://github.com/" + slug + "/issues"
-            scm          = "https://github.com/" + slug + ".git"
-        }
-
-        people {
-            person {
-                id    = 'musketyr'
-                name  = 'Vladimir Orany'
-                roles = ['developer']
-            }
-        }
-
-        repositories {
-            repository {
-                name = 'localRelease'
-                url  = "" + project.rootProject.buildDir + "/repos/local/release"
-            }
-            repository {
-                name = 'localSnapshot'
-                url  = "" + project.rootProject.buildDir + "/repos/local/snapshot"
-            }
-        }
-    }
-
-    licensing {
-        licenses {
-            license {
-                id = 'Apache-2.0'
-            }
-        }
-    }
-
-    publishing {
-        enabled = false
-        signing {
-            enabled = true
-            keyId = signingKeyId
-            secretKey = signingSecretKey
-            password = signingPassword
-        }
-        releasesRepository = 'localRelease'
-        snapshotsRepository = 'localSnapshot'
-    }
-
-    quality {
-        checkstyle {
-            toolVersion = '8.27'
-        }
-
-        codenarc {
-            toolVersion = '1.5'
-        }
-    }
-
-    docs {
-        javadoc {
-            autoLinks {
-                enabled = false
-            }
-            aggregate {
-                enabled = false
-            }
-        }
-        groovydoc {
-            enabled = false
-            aggregate {
-                enabled = false
-            }
-        }
-    }
-
-}
-
-nexusPublishing {
-    repositories {
-        sonatype {
-            nexusUrl = uri('https://s01.oss.sonatype.org/service/local/')
-            snapshotRepositoryUrl = uri('https://s01.oss.sonatype.org/content/repositories/snapshots/')
-            username = ossrhUsername
-            password = ossrhPassword
-        }
-    }
-}
+if (!project.hasProperty('mavenCentralUsername'))       ext.mavenCentralUsername       = System.getenv('MAVEN_CENTRAL_USERNAME') ?: '**UNDEFINED**'
+if (!project.hasProperty('mavenCentralPassword'))       ext.mavenCentralPassword       = System.getenv('MAVEN_CENTRAL_PASSWORD') ?: '**UNDEFINED**'
+if (!project.hasProperty('signingInMemoryKeyId'))       ext.signingInMemoryKeyId       = System.getenv('SIGNING_KEY_ID') ?: '**UNDEFINED**'
+if (!project.hasProperty('signingInMemoryKeyPassword')) ext.signingInMemoryKeyPassword = System.getenv('SIGNING_PASSWORD') ?: '**UNDEFINED**'
+if (!project.hasProperty('signingInMemoryKey'))         ext.signingInMemoryKey         = System.getenv('SIGNING_SECRET_KEY_PATH') ? rootProject.file(System.getenv('SIGNING_SECRET_KEY_PATH')).text : '**UNDEFINED**'
 
 allprojects {
     repositories {
         mavenCentral()
-        maven { url "https://repo.spring.io/release"  }
-    }
-
-    license {
-        exclude '**/*.json'
-        exclude '***.yml'
     }
 }
 
-gradleProjects {
-    subprojects {
-        dirs(['libs']) { Project subproject ->
-            java {
-                toolchain {
-                    languageVersion = JavaLanguageVersion.of(17)
-                }
-            }
-
-            micronaut {
-                importMicronautPlatform = true
-                testRuntime 'spock'
-                processing {
-                    incremental false
-                }
-            }
-
-            // location independent tests (useful for stable CI builds)
-            tasks.withType(Test) {
-                useJUnitPlatform()
-                systemProperty 'user.timezone', 'UTC'
-                systemProperty 'user.language', 'en'
-            }
-
-            tasks.withType(JavaCompile) {
-                options.encoding = "UTF-8"
-                options.compilerArgs.add('-parameters')
-            }
-
-            tasks.withType(GroovyCompile) {
-                groovyOptions.forkOptions.jvmArgs.add('-Dgroovy.parameters=true')
-            }
-
-            // useful for IntelliJ
-            task cleanOut(type: Delete) {
-                delete file('out')
-            }
-
-            clean.dependsOn cleanOut
-
-            processResources {
-                filesMatching('**/org.codehaus.groovy.runtime.ExtensionModule') {
-                    filter(org.apache.tools.ant.filters.ReplaceTokens, tokens: [VERSION: version])
-                }
-            }
-
-            jar {
-                manifest.attributes provider: 'gradle'
-            }
-
-            config {
-                publishing {
-                    enabled = true
-                }
+subprojects {
+    plugins.withId('com.agorapulse.gradle.micronaut-library') {
+        micronaut {
+            importMicronautPlatform = true
+            testRuntime 'spock'
+            processing {
+                incremental false
             }
         }
     }
+
+    plugins.withId('com.vanniktech.maven.publish') {
+        mavenPublishing {
+            publishToMavenCentral(true)
+            signAllPublications()
+
+            pom {
+                name = 'Micronaut Snitch'
+                description = 'Micronaut Snitch helps you to monitor running applications using services such as snitch.io'
+                inceptionYear = '2020'
+                url = "https://github.com/${slug}"
+                licenses {
+                    license {
+                        name = 'The Apache License, Version 2.0'
+                        url = 'https://www.apache.org/licenses/LICENSE-2.0.txt'
+                        distribution = 'https://www.apache.org/licenses/LICENSE-2.0.txt'
+                    }
+                }
+                developers {
+                    developer {
+                        id = 'musketyr'
+                        name = 'Vladimir Orany'
+                        url = 'https://github.com/musketyr/'
+                    }
+                }
+                scm {
+                    url = "https://github.com/${slug}.git"
+                    connection = "scm:git:git://github.com/${slug}.git"
+                    developerConnection = "scm:git:ssh://git@github.com/${slug}.git"
+                }
+            }
+        }
+
+        signing {
+            useInMemoryPgpKeys(rootProject.ext.signingInMemoryKey, rootProject.ext.signingInMemoryKeyPassword)
+            sign publishing.publications
+        }
+    }
 }
-
-
-check.dependsOn('aggregateCheckstyle', 'aggregateCodenarc', 'aggregateAllTestReports', 'coveralls')

--- a/docs/guide/guide.gradle
+++ b/docs/guide/guide.gradle
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2023 Agorapulse.
+ * Copyright 2020-2026 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,31 +16,18 @@
  * limitations under the License.
  */
 plugins {
-    id 'org.kordamp.gradle.guide'
-    id 'org.ajoberstar.git-publish'
+    id 'com.agorapulse.gradle.guide'
 }
 
-config {
-    docs {
-        guide {
-            publish {
-                enabled = true
-            }
-        }
-    }
-}
-
-configurations {
-    asciidoctorExtensions
-}
-
-dependencies {
-    asciidoctorExtensions 'com.bmuschko:asciidoctorj-tabbed-code-extension:0.3'
+// gradle-git-publish 5.x no longer reads GRGIT_USER / GRGIT_PASS env vars
+// (or the org.ajoberstar.grgit.auth.* system properties). HTTPS push
+// credentials must be set on the gitPublish extension directly.
+gitPublish {
+    username = providers.environmentVariable('GIT_PUBLISH_USERNAME').orElse('')
+    password = providers.environmentVariable('GIT_PUBLISH_PASSWORD').orElse('')
 }
 
 asciidoctor {
-    configurations 'asciidoctorExtensions'
-
     baseDirFollowsSourceDir()
 
     attributes = [
@@ -49,5 +36,4 @@ asciidoctor {
         'root-dir': rootDir,
         'project-slug': slug
     ]
-
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
-# Copyright 2020-2023 Agorapulse.
+# Copyright 2020-2026 Agorapulse.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,13 +16,18 @@
 # limitations under the License.
 #
 
+org.gradle.caching=true
+
 slug=agorapulse/micronaut-snitch
 group=com.agorapulse
-version=2.0.0-SNAPSHOT
-kordampPluginVersion=0.51.0
-nexusPluginVersion=1.0.0
+version=3.0.0-SNAPSHOT
+
+javaVersion = 25
+
+agorapulseGradlePluginsVersion = 4.4.2
+mavenCentralPublishPluginVersion = 0.34.0
+develocityPluginVersion = 4.2.2
 gitPublishPluginVersion=2.1.3
 
-micronautVersion = 4.2.0
-micronautGradlePluginVersion = 4.2.0
-
+micronautVersion = 5.0.0
+micronautGradlePluginVersion = 5.0.0

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradlew
+++ b/gradlew
@@ -1,21 +1,5 @@
 #!/usr/bin/env sh
 
-#
-# Copyright 2015 the original author or authors.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-
 ##############################################################################
 ##
 ##  Gradle start up script for UN*X
@@ -44,7 +28,7 @@ APP_NAME="Gradle"
 APP_BASE_NAME=`basename "$0"`
 
 # Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
-DEFAULT_JVM_OPTS='"-Xmx64m" "-Xms64m"'
+DEFAULT_JVM_OPTS=""
 
 # Use the maximum available, or set MAX_FD != -1 to use that value.
 MAX_FD="maximum"
@@ -125,8 +109,8 @@ if $darwin; then
     GRADLE_OPTS="$GRADLE_OPTS \"-Xdock:name=$APP_NAME\" \"-Xdock:icon=$APP_HOME/media/gradle.icns\""
 fi
 
-# For Cygwin or MSYS, switch paths to Windows format before running java
-if [ "$cygwin" = "true" -o "$msys" = "true" ] ; then
+# For Cygwin, switch paths to Windows format before running java
+if $cygwin ; then
     APP_HOME=`cygpath --path --mixed "$APP_HOME"`
     CLASSPATH=`cygpath --path --mixed "$CLASSPATH"`
     JAVACMD=`cygpath --unix "$JAVACMD"`
@@ -154,19 +138,19 @@ if [ "$cygwin" = "true" -o "$msys" = "true" ] ; then
         else
             eval `echo args$i`="\"$arg\""
         fi
-        i=`expr $i + 1`
+        i=$((i+1))
     done
     case $i in
-        0) set -- ;;
-        1) set -- "$args0" ;;
-        2) set -- "$args0" "$args1" ;;
-        3) set -- "$args0" "$args1" "$args2" ;;
-        4) set -- "$args0" "$args1" "$args2" "$args3" ;;
-        5) set -- "$args0" "$args1" "$args2" "$args3" "$args4" ;;
-        6) set -- "$args0" "$args1" "$args2" "$args3" "$args4" "$args5" ;;
-        7) set -- "$args0" "$args1" "$args2" "$args3" "$args4" "$args5" "$args6" ;;
-        8) set -- "$args0" "$args1" "$args2" "$args3" "$args4" "$args5" "$args6" "$args7" ;;
-        9) set -- "$args0" "$args1" "$args2" "$args3" "$args4" "$args5" "$args6" "$args7" "$args8" ;;
+        (0) set -- ;;
+        (1) set -- "$args0" ;;
+        (2) set -- "$args0" "$args1" ;;
+        (3) set -- "$args0" "$args1" "$args2" ;;
+        (4) set -- "$args0" "$args1" "$args2" "$args3" ;;
+        (5) set -- "$args0" "$args1" "$args2" "$args3" "$args4" ;;
+        (6) set -- "$args0" "$args1" "$args2" "$args3" "$args4" "$args5" ;;
+        (7) set -- "$args0" "$args1" "$args2" "$args3" "$args4" "$args5" "$args6" ;;
+        (8) set -- "$args0" "$args1" "$args2" "$args3" "$args4" "$args5" "$args6" "$args7" ;;
+        (9) set -- "$args0" "$args1" "$args2" "$args3" "$args4" "$args5" "$args6" "$args7" "$args8" ;;
     esac
 fi
 
@@ -175,9 +159,14 @@ save () {
     for i do printf %s\\n "$i" | sed "s/'/'\\\\''/g;1s/^/'/;\$s/\$/' \\\\/" ; done
     echo " "
 }
-APP_ARGS=`save "$@"`
+APP_ARGS=$(save "$@")
 
 # Collect all arguments for the java command, following the shell quoting and substitution rules
 eval set -- $DEFAULT_JVM_OPTS $JAVA_OPTS $GRADLE_OPTS "\"-Dorg.gradle.appname=$APP_BASE_NAME\"" -classpath "\"$CLASSPATH\"" org.gradle.wrapper.GradleWrapperMain "$APP_ARGS"
+
+# by default we should be in the correct project dir, but when run from Finder on Mac, the cwd is wrong
+if [ "$(uname)" = "Darwin" ] && [ "$HOME" = "$PWD" ]; then
+  cd "$(dirname "$0")"
+fi
 
 exec "$JAVACMD" "$@"

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -1,19 +1,3 @@
-@rem
-@rem Copyright 2015 the original author or authors.
-@rem
-@rem Licensed under the Apache License, Version 2.0 (the "License");
-@rem you may not use this file except in compliance with the License.
-@rem You may obtain a copy of the License at
-@rem
-@rem      https://www.apache.org/licenses/LICENSE-2.0
-@rem
-@rem Unless required by applicable law or agreed to in writing, software
-@rem distributed under the License is distributed on an "AS IS" BASIS,
-@rem WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-@rem See the License for the specific language governing permissions and
-@rem limitations under the License.
-@rem
-
 @if "%DEBUG%" == "" @echo off
 @rem ##########################################################################
 @rem
@@ -30,7 +14,7 @@ set APP_BASE_NAME=%~n0
 set APP_HOME=%DIRNAME%
 
 @rem Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
-set DEFAULT_JVM_OPTS="-Xmx64m" "-Xms64m"
+set DEFAULT_JVM_OPTS=
 
 @rem Find java.exe
 if defined JAVA_HOME goto findJavaFromJavaHome

--- a/libs/micronaut-snitch/micronaut-snitch.gradle
+++ b/libs/micronaut-snitch/micronaut-snitch.gradle
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2023 Agorapulse.
+ * Copyright 2020-2026 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2023 Agorapulse.
+ * Copyright 2020-2026 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,51 +15,57 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        maven { url 'https://agorapulse.jfrog.io/agorapulse/gradle-plugins-releases-local/' }
+        mavenCentral()
+    }
+    plugins {
+        id 'com.agorapulse.gradle.micronaut-library'           version "${agorapulseGradlePluginsVersion}"
+        id 'com.agorapulse.gradle.groovy-common-configuration' version "${agorapulseGradlePluginsVersion}"
+        id 'com.agorapulse.gradle.guide'                       version "${agorapulseGradlePluginsVersion}"
+        id 'com.vanniktech.maven.publish'                      version "${mavenCentralPublishPluginVersion}"
+    }
+}
+
 buildscript {
     repositories {
-        mavenCentral()
         gradlePluginPortal()
+        maven { url 'https://agorapulse.jfrog.io/agorapulse/gradle-plugins-releases-local/' }
     }
     dependencies {
-        classpath group: 'org.kordamp.gradle',          name: 'settings-gradle-plugin',         version: kordampPluginVersion
-        classpath group: 'org.kordamp.gradle',          name: 'groovy-project-gradle-plugin',   version: kordampPluginVersion
-        classpath group: 'org.kordamp.gradle',          name: 'checkstyle-gradle-plugin',       version: kordampPluginVersion
-        classpath group: 'org.kordamp.gradle',          name: 'codenarc-gradle-plugin',         version: kordampPluginVersion
-        classpath group: 'org.kordamp.gradle',          name: 'guide-gradle-plugin',            version: kordampPluginVersion
-        classpath group: 'org.kordamp.gradle',          name: 'coveralls-gradle-plugin',        version: kordampPluginVersion
-        classpath group: 'org.ajoberstar',              name: 'gradle-git-publish',             version: gitPublishPluginVersion
-        classpath group: 'io.github.gradle-nexus',      name: 'publish-plugin',                 version: nexusPluginVersion
-        classpath group: 'io.micronaut.gradle',         name: 'micronaut-minimal-plugin',       version: micronautGradlePluginVersion
+        classpath group: 'io.micronaut.gradle',   name: 'micronaut-minimal-plugin',     version: micronautGradlePluginVersion
+        classpath group: 'com.agorapulse.gradle', name: 'micronaut-library',            version: agorapulseGradlePluginsVersion
+        classpath group: 'com.agorapulse.gradle', name: 'groovy-common-configuration',  version: agorapulseGradlePluginsVersion
+        classpath group: 'com.vanniktech',        name: 'gradle-maven-publish-plugin',  version: mavenCentralPublishPluginVersion
     }
 }
 
 plugins {
-    id 'com.gradle.enterprise' version '3.15.1'
+    id 'com.agorapulse.gradle.settings' version "${agorapulseGradlePluginsVersion}"
+    id 'com.gradle.develocity'          version "${develocityPluginVersion}"
 }
 
-gradleEnterprise {
+develocity {
     buildScan {
-        publishAlways()
-        termsOfServiceUrl = "https://gradle.com/terms-of-service"
-        termsOfServiceAgree = "yes"
+        termsOfUseUrl = 'https://gradle.com/terms-of-service'
+        termsOfUseAgree = 'yes'
+        publishing.onlyIf { true }
     }
 }
 
-apply plugin:  'org.kordamp.gradle.settings'
-
-rootProject.name = 'micronaut-snitch-root'
-
-projects {
+gradleProjects {
     directories = ['libs', 'docs']
 
     plugins {
-        dir('docs') {
-            id 'org.kordamp.gradle.guide'
-            id 'org.ajoberstar.git-publish'
-        }
-        dirs(['libs', 'examples']) {
-            id 'io.micronaut.minimal.library'
+        dirs(['libs']) {
             id 'groovy'
+            id 'com.agorapulse.gradle.micronaut-library'
+            id 'com.agorapulse.gradle.groovy-common-configuration'
+            id 'com.vanniktech.maven.publish'
         }
     }
 }
+
+rootProject.name = 'micronaut-snitch-root'


### PR DESCRIPTION
## Summary

Migrates micronaut-snitch from the legacy Kordamp / Micronaut 4 build to the modern Agorapulse Gradle Plugins / Micronaut 5 / Java 25 / Gradle 9.5 stack, matching the layout already shipped in `micronaut-rethrow` and `micronaut-log4aws`.

### Upstream context

- micronaut-rethrow 3.0.0 (Mn 5) and micronaut-log4aws (Mn 5) are the reference templates
- agorapulseGradlePluginsVersion = 4.4.2
- mavenCentralPublishPluginVersion = 0.34.0 (vanniktech)
- develocityPluginVersion = 4.2.2
- micronautVersion = 5.0.0
- micronautGradlePluginVersion = 5.0.0

### Changes

- **Build** — replaced Kordamp `config { ... }` with `subprojects { plugins.withId(...) }` + `mavenPublishing { pom { ... } }` + in-memory signing
- **settings.gradle** — switched to `com.agorapulse.gradle.settings` + `gradleProjects` DSL; declared plugins via `pluginManagement`
- **gradle.properties** — bumped `version=3.0.0-SNAPSHOT`, `javaVersion=25`, `micronautVersion=5.0.0`, `micronautGradlePluginVersion=5.0.0`
- **gradle wrapper** — Gradle 9.5.0
- **docs/guide/guide.gradle** — dropped Kordamp guide plugin + `asciidoctorExtensions { ... }` wiring; added gradle-git-publish 5.x `username`/`password` block driven by `GIT_PUBLISH_USERNAME` / `GIT_PUBLISH_PASSWORD`
- **.github/workflows/release.yml** — Java 25 / zulu, `gradle/actions/setup-gradle@v5`, configures the `agorapulse-bot` git identity, runs `:guide:gitPublishPush publishAndReleaseToMavenCentral` with `GIT_PUBLISH_*` env vars; ping job now reports `micronautCompatibility=[5]`
- **.github/workflows/publish_documentation.yml** — Java 25, drops the legacy `-Dorg.ajoberstar.grgit.auth.username=...` flag (gradle-git-publish 5.x ignores it) in favour of `GIT_PUBLISH_*` env vars
- **.github/workflows/gradle.yml** + **license_updater.yml** — Java 25, `setup-gradle@v5`
- No source changes — the snitch `@Header` / `@Get` HTTP client API is stable across Mn 4 → 5

The `com.agorapulse.gradle.micronaut-compatibility` plugin is intentionally **not** introduced; snitch now targets Micronaut 5 only, matching the decision log4aws made (see log4aws commit `d398917`).

## Test plan

- [x] `./gradlew check` passes locally on JDK 25 / Gradle 9.5
- [x] All 11 Spock tests in `SnitchServiceSpec` pass (0 failures)
- [ ] CI `Check` workflow green on GitHub
- [ ] Release dry-run: confirm `:guide:gitPublishPush publishAndReleaseToMavenCentral` resolves on a tag
